### PR TITLE
Fix ES module examples

### DIFF
--- a/example/parse.js
+++ b/example/parse.js
@@ -1,6 +1,9 @@
-const fs = require('node:fs');
-const path = require('node:path');
-const { parse } = require('../index.js');
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from '../index.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const ENV_PATH = path.resolve(__dirname, '.env');
 const content = fs.readFileSync(ENV_PATH, 'utf8');
@@ -9,5 +12,5 @@ const parsed = parse(content, { coerce: true });
 
 console.log('🧪 Parsed (typed values):');
 for (const [key, value] of Object.entries(parsed)) {
-	console.log(`- ${key}:`, value, `(${typeof value})`);
+        console.log(`- ${key}:`, value, `(${typeof value})`);
 }

--- a/example/process.js
+++ b/example/process.js
@@ -1,8 +1,15 @@
+import { config } from '../index.js';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 console.time('execution');
 
-require('../index.js').config();
+config({ path: path.join(__dirname, '.env') });
 
 const msg = process.env.GREETING;
 console.log('process.env.GREETING:', msg);
 
 console.timeEnd('execution');
+

--- a/example/version.js
+++ b/example/version.js
@@ -1,3 +1,3 @@
-const { version } = require('../index.js');
+import { version } from '../index.js';
 
 console.log('Version:', version);


### PR DESCRIPTION
## Summary
- update example scripts to use ES module syntax
- fix path handling in `process.js`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/env-native/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_6876fcf6d3f0832ca3698a98915e31db